### PR TITLE
Constructor requires fewer parameters. Added onPress and onRelease methods to set handlers after construction

### DIFF
--- a/Button.class.nut
+++ b/Button.class.nut
@@ -20,9 +20,9 @@ class Button {
         _pin             = pin;
         _pull            = pull;
 
-        if (_polarity == null) {
-            if (pull == DIGITAL_IN_PULLUP) polarity = NORMALLY_HIGH;
-            else polarity = NORMALLY_LOW;
+        if (polarity == null) {
+            if (pull == DIGITAL_IN_PULLDOWN) polarity = NORMALLY_LOW;
+            else polarity = NORMALLY_HIGH;
         }
 
         _polarity        = polarity;
@@ -34,10 +34,12 @@ class Button {
 
     function onPress(cb) {
         _pressCallback = cb;
+        return this;
     }
 
     function onRelease(cb) {
         _releaseCallback = cb;
+        return this;
     }
 
     /******************** PRIVATE FUNCTIONS (DO NOT CALL) ********************/

--- a/Button.class.nut
+++ b/Button.class.nut
@@ -8,25 +8,25 @@ class Button {
     static version = [1, 1, 0];
 
     static NORMALLY_HIGH = 1;
-    static NORMALLY_LOW  = 0;
+    static NORMALLY_LOW = 0;
 
-    _pin             = null;
-    _pull            = null;
-    _polarity        = null;
-    _pressCallback   = null;
+    _pin = null;
+    _pull = null;
+    _polarity = null;
+    _pressCallback = null;
     _releaseCallback = null;
 
     constructor(pin, pull, polarity = null, pressCallback = null, releaseCallback = null) {
-        _pin             = pin;
-        _pull            = pull;
+        _pin = pin;
+        _pull = pull;
 
         if (polarity == null) {
-            if (pull == DIGITAL_IN_PULLDOWN) polarity = NORMALLY_LOW;
+            if (pull == DIGITAL_IN_PULLDOWN || pull == DIGITAL_IN_WAKEUP) polarity = NORMALLY_LOW;
             else polarity = NORMALLY_HIGH;
         }
 
-        _polarity        = polarity;
-        _pressCallback   = pressCallback;
+        _polarity = polarity;
+        _pressCallback = pressCallback;
         _releaseCallback = releaseCallback;
 
         _pin.configure(_pull, _debounce.bindenv(this));

--- a/Button.class.nut
+++ b/Button.class.nut
@@ -1,39 +1,54 @@
-// Copyright (c) 2013 Electric Imp
+// Copyright (c) 2015 Electric Imp
 // This file is licensed under the MIT License
 // http://opensource.org/licenses/MIT
 //
 // Description: Debounced button press with callbacks
 
-class Button
-{
+class Button {
+    static version = [1, 1, 0];
+
+    static NORMALLY_HIGH = 1;
+    static NORMALLY_LOW  = 0;
+
     _pin             = null;
     _pull            = null;
     _polarity        = null;
     _pressCallback   = null;
     _releaseCallback = null;
 
-    constructor(pin, pull, polarity, pressCallback, releaseCallback)
-    {
-        _pin             = pin;               // Unconfigured IO pin, eg hardware.pin2
-        _pull            = pull;              // DIGITAL_IN_PULLDOWN, DIGITAL_IN or DIGITAL_IN_PULLUP
-        _polarity        = polarity;          // Normal button state, ie 1 if button is pulled up and the button shorts to GND
-        _pressCallback   = pressCallback;     // Function to call on a button press (may be null)
-        _releaseCallback = releaseCallback;   // Function to call on a button release (may be null)
+    constructor(pin, pull, polarity = null, pressCallback = null, releaseCallback = null) {
+        _pin             = pin;
+        _pull            = pull;
+
+        if (_polarity == null) {
+            if (pull == DIGITAL_IN_PULLUP) polarity = NORMALLY_HIGH;
+            else polarity = NORMALLY_LOW;
+        }
+
+        _polarity        = polarity;
+        _pressCallback   = pressCallback;
+        _releaseCallback = releaseCallback;
 
         _pin.configure(_pull, _debounce.bindenv(this));
     }
 
-    /*** PRIVATE FUNCTIONS ***/
+    function onPress(cb) {
+        _pressCallback = cb;
+    }
 
-    function _debounce()
-    {
+    function onRelease(cb) {
+        _releaseCallback = cb;
+    }
+
+    /******************** PRIVATE FUNCTIONS (DO NOT CALL) ********************/
+    function _debounce() {
         // Make sure callback isn’t triggered during debounce period
         _pin.configure(_pull);
 
         imp.wakeup(0.010, _getState.bindenv(this));  // Bounce times are usually limited to 10ms
     }
 
-    function _getState(){
+    function _getState() {
         if( _polarity == _pin.read() )
         {
             if(_releaseCallback != null)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Electric Imp
+Copyright (c) 2015 Electric Imp
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ This Squirrel class implements debouncing for buttons connected to an imp. It re
 The Button constructor has two required parameters - *pin*, and *pull* - and three optional parameters - *polarity*, *pressCallback*, *releaseCallback*.
 
 - *pin* &ndash; the *unconfigured* impOS pin object the button is wired to (e.g. ```hardware.pin1```)
-- *pull* &ndash; the impOS constant used to configure the digital input (either ```DIGITAL_IN```, ```DIGITAL_IN_PULLDOWN```, or ```DIGITAL_IN_PULLUP```)
-- *polarity* &ndash; the unpressed button state (either ```Button.NORMALLY_HIGH``` or ```Button.NORMALLY_LOW```). If this parameter is not passed to the ctor, it will be infered based on the pull parameter:
-    - ```DIGITAL_IN_PULLDOWN``` - ```Button.NORMALLY_LOW```
-    - ```DIGITAL_IN_PULLUP``` - ```Button.NORMALLY_HIGH```
+- *pull* &ndash; the impOS constant used to configure the digital input (```DIGITAL_IN```, ```DIGITAL_IN_PULLDOWN```, ```DIGITAL_IN_PULLUP```, or ```DIGITAL_IN_WAKEUP```)
+- *polarity* &ndash; the unpressed button state (```Button.NORMALLY_HIGH``` or ```Button.NORMALLY_LOW```). If this parameter is not passed to the ctor, it will be infered based on the pull parameter:
     - ```DIGITAL_IN``` - ```Button.NORMALLY_HIGH```
+    - ```DIGITAL_IN_PULLUP``` - ```Button.NORMALLY_HIGH```
+    - ```DIGITAL_IN_PULLDOWN``` - ```Button.NORMALLY_LOW```
+    - ```DIGITAL_IN_WAKEUP``` - ```Button.NORMALLY_LOW```
 - *pressCallback* &ndash; the callback function (no parameters) to be executed when the button is pressed.
 - *releaseCallback* &ndash; the callback function (no parameters) to be executed when the button is released.
 

--- a/README.md
+++ b/README.md
@@ -4,23 +4,43 @@ This Squirrel class implements debouncing for buttons connected to an imp. It re
 
 ## Class Usage
 
-## Constructor:<br>Button(*pin, pull, polarity, pressCallback, releaseCallback*)
+## constructor(*pin, pull, [polarity], [pressCallback], [releaseCallback]*)
 
-To instantiate a Button object, pass it the following parameters:
+The Button constructor has two required parameters - *pin*, and *pull* - and three optional parameters - *polarity*, *pressCallback*, *releaseCallback*.
 
-- *pin* &ndash; the *unconfigured* impOS pin object representing the pin to which the button is wired
-- *pull* &ndash; an impOS constant, either *DIGITAL_IN_PULLDOWN*, *DIGITAL_IN* or *DIGITAL_IN_PULLUP*
-- *polarity* &ndash; the unpressed button state, eg. 1 if the button is pulled up and the button shorts to GND
-- *pressCallback* &ndash; the function to be called if the button is pressed, or `null` if you don’t want to monitor button presses)
-- *releaseCallback* &ndash; the function to be called if the button is release, or `null` if you don’t want to monitor button releases)
-
-The following code shows a typical example of the class’ use. A button is connected to an imp’s pin 7. The other side of the switch runs to GND. Single presses are best monitored by checking for button releases, so that the user’s action is not implemented if they press and hold the button. The button is used to switch an LCD display’s backlight on and off.
+- *pin* &ndash; the *unconfigured* impOS pin object the button is wired to (e.g. ```hardware.pin1```)
+- *pull* &ndash; the impOS constant used to configure the digital input (either ```DIGITAL_IN```, ```DIGITAL_IN_PULLDOWN```, or ```DIGITAL_IN_PULLUP```)
+- *polarity* &ndash; the unpressed button state (either ```Button.NORMALLY_HIGH``` or ```Button.NORMALLY_LOW```). If this parameter is not passed to the ctor, it will be infered based on the pull parameter:
+    - ```DIGITAL_IN``` - ```Button.NORMALLY_LOW```
+    - ```DIGITAL_IN_PULLDOWN``` - ```Button.NORMALLY_LOW```
+    - ```DIGITAL_IN_PULLUP``` - ```Button.NORMALLY_HIGH```
+- *pressCallback* &ndash; the callback function (no parameters) to be executed when the button is pressed.
+- *releaseCallback* &ndash; the callback function (no parameters) to be executed when the button is released.
 
 ```squirrel
-button <- Button(hardware.pin7, DIGITAL_IN_PULLUP, 1, null, function() {
-  backlightFlag = !backlightFlag
-  display.setBacklight(backlightFlag)
-})
+#require "button.class.nut:1.1.0"
+
+button <- Button(hardware.pin7, DIGITAL_IN_PULLUP);
+```
+
+## button.onPress(callback)
+
+The *onPress* method sets the callback for the button's onPress event (i.e. when the button is depressed). If an onPress callback function is already registered, it will be replaced with the new callback. Setting the callback to ```null``` will result in no action when the button is pressed (this is the default behavior).
+
+```squirrel
+button.onPress(function() {
+  server.log("Button Pressed!");
+});
+```
+
+## button.onRelease(callback)
+
+The *onRelease* method sets the callback for the button's onRelease event (i.e. when the button is released). If an onRelease callback function is already registered, it will be replaced with the new callback. Setting the callback to ```null``` will result in no action when the button is released (this is the default behavior).
+
+```squirrel
+button.onRelease(function() {
+  server.log("Button Released!");
+});
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ The Button constructor has two required parameters - *pin*, and *pull* - and thr
 - *pin* &ndash; the *unconfigured* impOS pin object the button is wired to (e.g. ```hardware.pin1```)
 - *pull* &ndash; the impOS constant used to configure the digital input (either ```DIGITAL_IN```, ```DIGITAL_IN_PULLDOWN```, or ```DIGITAL_IN_PULLUP```)
 - *polarity* &ndash; the unpressed button state (either ```Button.NORMALLY_HIGH``` or ```Button.NORMALLY_LOW```). If this parameter is not passed to the ctor, it will be infered based on the pull parameter:
-    - ```DIGITAL_IN``` - ```Button.NORMALLY_LOW```
     - ```DIGITAL_IN_PULLDOWN``` - ```Button.NORMALLY_LOW```
     - ```DIGITAL_IN_PULLUP``` - ```Button.NORMALLY_HIGH```
+    - ```DIGITAL_IN``` - ```Button.NORMALLY_HIGH```
 - *pressCallback* &ndash; the callback function (no parameters) to be executed when the button is pressed.
 - *releaseCallback* &ndash; the callback function (no parameters) to be executed when the button is released.
 


### PR DESCRIPTION
Attempt to simplify Button class to make it easier to use for new devs
- Only Pin and Pull are required parameters for constructor
- If a polarity is not passed in, it is assumed based on pull
- Added onPress and onRelease methods that allow you to set callbacks after construction
  - This makes for especially clear code and examples! 
