### PR TITLE
Fix issue with non-firing release events due to the debouncing order

### DIFF
--- a/Button.class.nut
+++ b/Button.class.nut
@@ -5,7 +5,7 @@
 // Description: Debounced button press with callbacks
 
 class Button {
-    static version = [1, 1, 0];
+    static version = [1, 1, 1];
 
     static NORMALLY_HIGH = 1;
     static NORMALLY_LOW = 0;
@@ -51,6 +51,9 @@ class Button {
     }
 
     function _getState() {
+        // Re-enabled callback after button action - it's important that this happens first in case we have "long running" callbacks!
+        _pin.configure(_pull, _debounce.bindenv(this));
+
         if( _polarity == _pin.read() )
         {
             if(_releaseCallback != null)
@@ -65,8 +68,5 @@ class Button {
                 _pressCallback();
             }
         }
-
-        // Re-enabled callback after button action
-        _pin.configure(_pull, _debounce.bindenv(this));
     }
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This Squirrel class implements debouncing for buttons connected to an imp. It requires one line of code in your device firmware: to instantiate the class. This involves passing callback functions that will be executed, respectively, when the button is pressed and then released. The class automatically handles bounces, ensuring your callbacks are only run when the button has been intentionally pressed and released.
 
-**To add this library to your project, add** `#require "Button.class.nut:1.1.0"` **to the top of your device code**
+**To add this library to your project, add** `#require "Button.class.nut:1.1.1"` **to the top of your device code**
 
 ## Class Usage
 
@@ -43,6 +43,22 @@ The *onRelease* method sets the callback for the button's onRelease event (i.e. 
 ```squirrel
 button.onRelease(function() {
   server.log("Button Released!");
+});
+```
+
+## Method Chaining
+
+All methods return the ```this``` - the instance of the instantiated object.  This allows method chaining as shown below.
+
+```squirrel
+Button(hardware.pin1, DIGITAL_IN_WAKEUP)
+.onPress(function() {
+    server.log("Pressed");
+}).onRelease(function() {
+    server.log("Released.. going to sleep");
+    imp.onidle(function() { server.sleepfor(3600); });
+}).onWakeup(function() {
+    server.log("Woke from button press");
 });
 ```
 


### PR DESCRIPTION
Since the _press and _release callbacks are called in-line in the
getState() function before re-enabling callbacks, if those functions
take a "long time" then there will be no callback for the next release.

By moving _pin.configure to the top of the _getState() function, this
bug disappears.
