### PR TITLE
Allow onPress and onRelease functions to take no arguments

### DIFF
--- a/Button.class.nut
+++ b/Button.class.nut
@@ -32,12 +32,12 @@ class Button {
         _pin.configure(_pull, _debounce.bindenv(this));
     }
 
-    function onPress(cb) {
+    function onPress(cb=null) {
         _pressCallback = cb;
         return this;
     }
 
-    function onRelease(cb) {
+    function onRelease(cb=null) {
         _releaseCallback = cb;
         return this;
     }


### PR DESCRIPTION
This allows you to easily erase/disable the onPress and onRelease callback functions.  The rest of the button class already deals with them being set to null.

``` squirrel
btn.onPress(function(){
  // Do some stuff 1 time only

  btn.onPress() // Remove the callback function
}
```

The code and README need to be version bumped.
